### PR TITLE
V0.1.0a79 manual

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiled" %}
-{% set version = "0.1.0a77" %}
+{% set version = "0.1.0a79" %}
 
 package:
   name: tiled-suite
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/tiled-{{ version }}.tar.gz
-  sha256: 6137ac57ef2b70638fdc485b9fe016070f8c21b3fa0cd5d25d348cb8fe73c67b
+  sha256: 5abe6758eef5ead7e62fea52165c27b72d4cb8a4ab3aa4b8a2096ba6301e91fb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ outputs:
         - blosc
         - click !=8.1.0
         - dask
+        - httpx >=0.20.0
         - jsonschema
         - lz4
         - msgpack-python >=1.0.0
@@ -52,7 +53,6 @@ outputs:
       run:
         - entrypoints
         - heapdict
-        - httpx
         - {{ pin_subpackage('tiled-base', exact=True) }}
     test:
       imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This was just re-rendered yesterday for v0.1.0a77 in #18. This branches off of that and accounts for changes in the deps since v0.1.0a77:

```
$ find . -name "requirements*" | xargs git diff v0.1.0a77 --
diff --git a/requirements-server.txt b/requirements-server.txt
index 98f9a662..c7f6094d 100644
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -2,16 +2,19 @@
 aiofiles
 alembic
 anyio
+appdirs
 cachey
 cachetools
 click !=8.1.0
 dask
 fastapi
+httpx >=0.20.0
 jinja2
 jmespath
 jsonschema
 msgpack >=1.0.0
 orjson
+packaging
 psutil
 prometheus_client
 pydantic >=1.8.2
```